### PR TITLE
Fixed the selected region show in atom v1.21

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -43,6 +43,11 @@ atom-text-editor {
     border-color: @syntax-cursor-color;
   }
 
+  .selection .region
+  {
+    background-color: @syntax-selection-color;
+  }
+
   .is-focused .selection .region {
     background-color: @syntax-selection-color;
   }


### PR DESCRIPTION
When I update atom to v1.21, the selected text can not show the background.
Fixed the selected region show in atom v1.21